### PR TITLE
Add RTC support (Epson RX8130CE)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -326,7 +326,7 @@ The project uses the following language versions:
 |---|---|
 | Chip | Epson RX8130CE |
 | I2C address | 0x32 |
-| I2C bus pins | SDA = GPIO 7, SCL = GPIO 8 |
+| I2C bus pins | SDA = GPIO 31, SCL = GPIO 32 (shared internal bus, `I2C_NUM_1`) |
 | Interrupt | /IRQ via PMS150G-U06 to ESP32-P4 GPIO (configure separately) |
 
 - Opens an I2C master bus using the ESP-IDF v5 `esp_driver_i2c` component.
@@ -373,6 +373,7 @@ if (rtc != nullptr)
 ```
 
 **Key constraints:**
+- The RTC sits on the **internal I2C bus** (`I2C_NUM_1`, GPIO 31/32), which M5GFX also uses for the touch controller and IO expanders.  The constructor calls `i2c_master_get_bus_handle(I2C_NUM_1, ...)` to reuse the existing bus handle created by `display.init()` rather than opening a second one.  `Rtc::Initialise()` must therefore be called **after** `display.init()`.
 - After a power-on reset the VLF flag will be set; the driver logs a warning and performs a software reset.  The time must be re-set by the application after any software reset.
 - The ESP32-P4 deep-sleep wakeup source must be configured by the application using `esp_sleep_enable_ext0_wakeup()` pointing at the GPIO connected to the /IRQ output.
 - All time fields follow standard C `struct tm` semantics: `tm_year` = years since 1900, `tm_mon` = 0–11.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,11 +35,13 @@ Tab5Template/
 │   └── CMakeLists.txt                # Registers Tab5Template.cpp; requires Tab5, m5unified, m5gfx
 ├── components/
 │   └── Tab5/
-│       ├── CMakeLists.txt            # Registers Tab5 component; requires m5gfx, driver, freertos, sdmmc, fatfs
+│       ├── CMakeLists.txt            # Registers Tab5 component; requires m5gfx, driver, freertos, sdmmc, fatfs, esp_driver_i2c
 │       ├── Touch.hpp                 # TouchInput singleton — interrupt-driven touch input
 │       ├── Touch.cpp
 │       ├── SDCard.hpp                # SDCard singleton — SDMMC 4-bit microSD mount
-│       └── SDCard.cpp
+│       ├── SDCard.cpp
+│       ├── Rtc.hpp                   # Rtc singleton — Epson RX8130CE real-time clock
+│       └── Rtc.cpp
 ├── CMakeLists.txt                    # Top-level; sets C++20, adds components/Tab5
 ├── partitions.csv                    # Custom 16 MB partition table (4 MB app + SPIFFS)
 ├── sdkconfig                         # Live build config — do not edit manually
@@ -313,3 +315,65 @@ The project uses the following language versions:
 - Use spaces after casts
 - Prefer `char *variable` over `char* variable` for pointer declarations
 - Prefer `char &variable` over `char& variable` for reference declarations
+
+---
+
+## RTC API (`components/Tab5/`)
+
+`Rtc` is a singleton class for the **Epson RX8130CE** real-time clock chip.
+
+| Item | Value |
+|---|---|
+| Chip | Epson RX8130CE |
+| I2C address | 0x32 |
+| I2C bus pins | SDA = GPIO 7, SCL = GPIO 8 |
+| Interrupt | /IRQ via PMS150G-U06 to ESP32-P4 GPIO (configure separately) |
+
+- Opens an I2C master bus using the ESP-IDF v5 `esp_driver_i2c` component.
+- On first power-up, checks the VLF (oscillation-stop) flag and issues a software reset if set.
+- Provides time read/write via the standard C `struct tm`.
+- Provides day/date alarm with independent enable bits for minute, hour, and day/weekday.
+- Provides a 16-bit countdown wakeup timer with selectable clock source.
+- `GetFlags()` / `ClearFlags()` manage the Flag Register (0x1D); call `ClearFlags(FLAG_ALARM)` after handling an alarm interrupt to deassert /IRQ.
+
+```cpp
+// Typical usage
+Rtc *rtc = Rtc::Initialise();
+if (rtc != nullptr)
+{
+    // Set the time (struct tm: year = years-since-1900, month = 0-based)
+    struct tm now = {};
+    now.tm_year  = 2026 - 1900;
+    now.tm_mon   = 0;           // January
+    now.tm_mday  = 15;
+    now.tm_hour  = 10;
+    now.tm_min   = 30;
+    now.tm_sec   = 0;
+    rtc->SetTime(now);
+
+    // Read the time back
+    struct tm current = {};
+    rtc->GetTime(current);
+
+    // Configure a day alarm at 07:00 on day 16
+    Rtc::AlarmConfig alarm;
+    alarm.matchMinute = true;
+    alarm.matchHour   = true;
+    alarm.matchDay    = true;
+    alarm.minute      = 0;
+    alarm.hour        = 7;
+    alarm.day         = 16;
+    alarm.matchWeekday = false;
+    rtc->SetAlarm(alarm);
+    rtc->EnableAlarmInterrupt(true);
+
+    // Configure a 60-second wakeup timer
+    rtc->StartWakeupTimer(60, Rtc::TimerClockSource::Hz1, true);
+}
+```
+
+**Key constraints:**
+- After a power-on reset the VLF flag will be set; the driver logs a warning and performs a software reset.  The time must be re-set by the application after any software reset.
+- The ESP32-P4 deep-sleep wakeup source must be configured by the application using `esp_sleep_enable_ext0_wakeup()` pointing at the GPIO connected to the /IRQ output.
+- All time fields follow standard C `struct tm` semantics: `tm_year` = years since 1900, `tm_mon` = 0–11.
+- IDF component `esp_driver_i2c` must be listed in `REQUIRES` (already added to `components/Tab5/CMakeLists.txt`).

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,5 +43,6 @@
     "idf.flashType": "UART",
     "cSpell.words": [
         "lvgl"
-    ]
+    ],
+    "idf.currentSetup": "/Users/markstevens/.espressif/v6.0/esp-idf"
 }

--- a/components/Tab5/CMakeLists.txt
+++ b/components/Tab5/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "SDCard.cpp" "Touch.cpp"
+idf_component_register(SRCS "SDCard.cpp" "Touch.cpp" "Rtc.cpp"
                     INCLUDE_DIRS "."
-                    REQUIRES m5gfx driver freertos sdmmc fatfs)
+                    REQUIRES m5gfx driver freertos sdmmc fatfs esp_driver_i2c)

--- a/components/Tab5/Rtc.cpp
+++ b/components/Tab5/Rtc.cpp
@@ -159,8 +159,8 @@ bool Rtc::GetTime(struct tm &time) const
         return (false);
     }
 
-    time.tm_sec  = static_cast<int>(BcdToDec(buffer[0] & 0x7F));
-    time.tm_min  = static_cast<int>(BcdToDec(buffer[1] & 0x7F));
+    time.tm_sec = static_cast<int>(BcdToDec(buffer[0] & 0x7F));
+    time.tm_min = static_cast<int>(BcdToDec(buffer[1] & 0x7F));
     time.tm_hour = static_cast<int>(BcdToDec(buffer[2] & 0x3F));
 
     // Weekday register is one-hot: bit 0 = Sunday, bit 6 = Saturday.
@@ -174,7 +174,7 @@ bool Rtc::GetTime(struct tm &time) const
     time.tm_wday = weekday;
 
     time.tm_mday = static_cast<int>(BcdToDec(buffer[4] & 0x3F));
-    time.tm_mon  = static_cast<int>(BcdToDec(buffer[5] & 0x1F)) - 1;
+    time.tm_mon = static_cast<int>(BcdToDec(buffer[5] & 0x1F)) - 1;
     time.tm_year = static_cast<int>(BcdToDec(buffer[6])) + TM_YEAR_OFFSET_2000;
     time.tm_isdst = -1;
 
@@ -192,7 +192,7 @@ bool Rtc::SetTime(const struct tm &time)
     buffer[0] = DecToBcd(static_cast<uint8_t>(time.tm_sec));
     buffer[1] = DecToBcd(static_cast<uint8_t>(time.tm_min));
     buffer[2] = DecToBcd(static_cast<uint8_t>(time.tm_hour));
-    buffer[3] = static_cast<uint8_t>(1u << time.tm_wday);              // One-hot weekday
+    buffer[3] = static_cast<uint8_t>(1u << time.tm_wday); // One-hot weekday
     buffer[4] = DecToBcd(static_cast<uint8_t>(time.tm_mday));
     buffer[5] = DecToBcd(static_cast<uint8_t>(time.tm_mon + 1));
     buffer[6] = DecToBcd(static_cast<uint8_t>(time.tm_year - TM_YEAR_OFFSET_2000));
@@ -240,12 +240,12 @@ bool Rtc::SetAlarm(const AlarmConfig &config)
     // Build the three alarm register bytes.  Bit 7 = 0 enables matching for
     // that field; bit 7 = 1 disables it.
     uint8_t alarmMinute = DecToBcd(config.minute);
-    uint8_t alarmHour   = DecToBcd(config.hour);
+    uint8_t alarmHour = DecToBcd(config.hour);
     uint8_t alarmDay;
 
     if (config.matchWeekday)
     {
-        alarmDay = static_cast<uint8_t>(1u << config.day);  // One-hot encoding
+        alarmDay = static_cast<uint8_t>(1u << config.day); // One-hot encoding
     }
     else
     {
@@ -265,7 +265,7 @@ bool Rtc::SetAlarm(const AlarmConfig &config)
         alarmDay |= ALARM_DISABLE_BIT;
     }
 
-    uint8_t packet[4] = { REG_ALARM_MIN, alarmMinute, alarmHour, alarmDay };
+    uint8_t packet[4] = {REG_ALARM_MIN, alarmMinute, alarmHour, alarmDay};
 
     esp_err_t result = i2c_master_transmit(_deviceHandle, packet, sizeof(packet), I2C_TIMEOUT_MS);
     return (result == ESP_OK);
@@ -285,13 +285,13 @@ bool Rtc::GetAlarm(AlarmConfig &config) const
         return (false);
     }
 
-    config.matchMinute  = (alarmBuffer[0] & ALARM_DISABLE_BIT) == 0;
-    config.matchHour    = (alarmBuffer[1] & ALARM_DISABLE_BIT) == 0;
-    config.matchDay     = (alarmBuffer[2] & ALARM_DISABLE_BIT) == 0;
+    config.matchMinute = (alarmBuffer[0] & ALARM_DISABLE_BIT) == 0;
+    config.matchHour = (alarmBuffer[1] & ALARM_DISABLE_BIT) == 0;
+    config.matchDay = (alarmBuffer[2] & ALARM_DISABLE_BIT) == 0;
     config.matchWeekday = (extensionReg & EXT_WADA) == 0;
 
     config.minute = BcdToDec(alarmBuffer[0] & 0x7F);
-    config.hour   = BcdToDec(alarmBuffer[1] & 0x7F);
+    config.hour = BcdToDec(alarmBuffer[1] & 0x7F);
 
     if (config.matchWeekday)
     {
@@ -337,9 +337,7 @@ bool Rtc::EnableAlarmInterrupt(bool enable)
 // Wakeup timer
 // =============================================================================
 
-bool Rtc::StartWakeupTimer(uint16_t countdownValue,
-                            TimerClockSource clockSource,
-                            bool enableInterrupt)
+bool Rtc::StartWakeupTimer(uint16_t countdownValue, TimerClockSource clockSource, bool enableInterrupt)
 {
     // Stop the timer before modifying its registers.
     uint8_t extensionReg = 0;
@@ -355,9 +353,9 @@ bool Rtc::StartWakeupTimer(uint16_t countdownValue,
     }
 
     // Write the 16-bit countdown value (little-endian: L byte then H byte).
-    const uint8_t timerLow  = static_cast<uint8_t>(countdownValue & 0xFF);
+    const uint8_t timerLow = static_cast<uint8_t>(countdownValue & 0xFF);
     const uint8_t timerHigh = static_cast<uint8_t>((countdownValue >> 8) & 0xFF);
-    uint8_t timerPacket[3] = { REG_TIMER_LOW, timerLow, timerHigh };
+    uint8_t timerPacket[3] = {REG_TIMER_LOW, timerLow, timerHigh};
 
     esp_err_t result = i2c_master_transmit(_deviceHandle, timerPacket, sizeof(timerPacket), I2C_TIMEOUT_MS);
     if (result != ESP_OK)
@@ -447,18 +445,14 @@ bool Rtc::ClearFlags(StatusFlags flags)
 
 bool Rtc::WriteRegister(uint8_t registerAddress, uint8_t value) const
 {
-    uint8_t packet[2] = { registerAddress, value };
+    uint8_t packet[2] = {registerAddress, value};
     esp_err_t result = i2c_master_transmit(_deviceHandle, packet, sizeof(packet), I2C_TIMEOUT_MS);
     return (result == ESP_OK);
 }
 
 bool Rtc::ReadRegisters(uint8_t registerAddress, uint8_t *buffer, size_t length) const
 {
-    esp_err_t result = i2c_master_transmit_receive(
-        _deviceHandle,
-        &registerAddress, 1,
-        buffer, length,
-        I2C_TIMEOUT_MS);
+    esp_err_t result = i2c_master_transmit_receive(_deviceHandle, &registerAddress, 1, buffer, length, I2C_TIMEOUT_MS);
     return (result == ESP_OK);
 }
 
@@ -516,11 +510,11 @@ bool Rtc::PerformStartup()
         // Software reset sequence from the RX8130CE datasheet / application note.
         WriteRegister(REG_CONTROL0, 0x00);
         WriteRegister(REG_CONTROL0, CTRL0_STOP);
-        WriteRegister(0x50, 0x6C);  // Undocumented internal reset register
-        WriteRegister(0x53, 0x01);  // Undocumented internal reset register
-        WriteRegister(0x66, 0x03);  // Undocumented internal reset register
-        WriteRegister(0x6B, 0x02);  // Undocumented internal reset register
-        WriteRegister(0x6B, 0x01);  // Undocumented internal reset register
+        WriteRegister(0x50, 0x6C); // Undocumented internal reset register
+        WriteRegister(0x53, 0x01); // Undocumented internal reset register
+        WriteRegister(0x66, 0x03); // Undocumented internal reset register
+        WriteRegister(0x6B, 0x02); // Undocumented internal reset register
+        WriteRegister(0x6B, 0x01); // Undocumented internal reset register
 
         vTaskDelay(pdMS_TO_TICKS(RESET_WAIT_MS));
 

--- a/components/Tab5/Rtc.cpp
+++ b/components/Tab5/Rtc.cpp
@@ -90,22 +90,30 @@ Rtc *Rtc::Initialise()
 // Constructor / Destructor
 // =============================================================================
 
-Rtc::Rtc() : _busHandle(nullptr), _deviceHandle(nullptr), _initialised(false)
+Rtc::Rtc() : _busHandle(nullptr), _deviceHandle(nullptr), _initialised(false), _busOwned(false)
 {
-    // Open an I2C master bus on the Tab5 RTC pins.
-    i2c_master_bus_config_t busConfig = {};
-    busConfig.i2c_port = I2C_NUM_0;
-    busConfig.sda_io_num = RTC_SDA_PIN;
-    busConfig.scl_io_num = RTC_SCL_PIN;
-    busConfig.clk_source = I2C_CLK_SRC_DEFAULT;
-    busConfig.glitch_ignore_cnt = 7;
-    busConfig.flags.enable_internal_pullup = true;
-
-    esp_err_t result = i2c_new_master_bus(&busConfig, &_busHandle);
+    // Attempt to reuse the I2C_NUM_1 bus that M5GFX creates during display.init().
+    // IDF v5.x rejects a second i2c_new_master_bus() call on the same port number,
+    // so we retrieve the existing handle when available.
+    esp_err_t result = i2c_master_get_bus_handle(I2C_NUM_1, &_busHandle);
     if (result != ESP_OK)
     {
-        ESP_LOGE(LOG_TAG, "Failed to create I2C master bus: %s", esp_err_to_name(result));
-        return;
+        // Bus not yet claimed — open it ourselves.
+        i2c_master_bus_config_t busConfig = {};
+        busConfig.i2c_port = I2C_NUM_1;
+        busConfig.sda_io_num = RTC_SDA_PIN;
+        busConfig.scl_io_num = RTC_SCL_PIN;
+        busConfig.clk_source = I2C_CLK_SRC_DEFAULT;
+        busConfig.glitch_ignore_cnt = 7;
+        busConfig.flags.enable_internal_pullup = true;
+
+        result = i2c_new_master_bus(&busConfig, &_busHandle);
+        if (result != ESP_OK)
+        {
+            ESP_LOGE(LOG_TAG, "Failed to create I2C master bus: %s", esp_err_to_name(result));
+            return;
+        }
+        _busOwned = true;
     }
 
     // Add the RX8130CE device to the bus.
@@ -140,7 +148,10 @@ Rtc::~Rtc()
 
     if (_busHandle != nullptr)
     {
-        i2c_del_master_bus(_busHandle);
+        if (_busOwned)
+        {
+            i2c_del_master_bus(_busHandle);
+        }
         _busHandle = nullptr;
     }
 

--- a/components/Tab5/Rtc.cpp
+++ b/components/Tab5/Rtc.cpp
@@ -1,0 +1,542 @@
+/*-----------------------------------------------------------------------------
+ * File        : Rtc.cpp
+ * Description : Implementation of the Rtc singleton for the Epson RX8130CE
+ *               real-time clock on the M5Stack Tab5.  The chip is accessed
+ *               over I2C using the ESP-IDF v5 new i2c_master driver.  On
+ *               first power-up the startup sequence detects an oscillation
+ *               stop (VLF flag) and issues a software reset as required by
+ *               the datasheet.
+ * Author      : Mark Stevens
+ * Copyright   : Copyright (c) 2026 Mark Stevens
+ * Licence     : MIT — see LICENSE in the repository root for full terms.
+ * Target      : M5Stack Tab5 (ESP32-P4)
+ * Build system: ESP-IDF v5.5.1
+ *---------------------------------------------------------------------------*/
+
+#include "Rtc.hpp"
+
+#include <cstring>
+#include <esp_log.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+/** @brief Logging tag used for all ESP-IDF log output from this module. */
+static constexpr const char *LOG_TAG = "Rtc";
+
+/** @brief I2C transaction timeout in milliseconds. */
+static constexpr int I2C_TIMEOUT_MS = 100;
+
+/** @brief Startup wait time in milliseconds (datasheet §8.3: ≥30 ms). */
+static constexpr int STARTUP_WAIT_MS = 35;
+
+/** @brief Software reset completion wait time (datasheet: ≥125 ms). */
+static constexpr int RESET_WAIT_MS = 130;
+
+/** @brief Control Register 0 bit: stop the timekeeping oscillator. */
+static constexpr uint8_t CTRL0_STOP = 0x40;
+
+/** @brief Control Register 0 bit: alarm interrupt enable. */
+static constexpr uint8_t CTRL0_AIE = 0x08;
+
+/** @brief Control Register 0 bit: timer interrupt enable. */
+static constexpr uint8_t CTRL0_TIE = 0x10;
+
+/** @brief Extension Register bit: timer enable. */
+static constexpr uint8_t EXT_TE = 0x10;
+
+/** @brief Extension Register bit: WADA (0=week alarm, 1=day alarm). */
+static constexpr uint8_t EXT_WADA = 0x08;
+
+/** @brief Extension Register mask: timer clock source bits [2:0]. */
+static constexpr uint8_t EXT_TSEL_MASK = 0x07;
+
+/** @brief Alarm register bit 7: disable this alarm channel. */
+static constexpr uint8_t ALARM_DISABLE_BIT = 0x80;
+
+/** @brief Offset from year-2000 in tm_year (years-since-1900) scale. */
+static constexpr int TM_YEAR_OFFSET_2000 = 100;
+
+/** @brief Initialise the static singleton pointer to null. */
+Rtc *Rtc::_instance = nullptr;
+
+// =============================================================================
+// Public static interface
+// =============================================================================
+
+Rtc *Rtc::GetInstance()
+{
+    return (_instance);
+}
+
+Rtc *Rtc::Initialise()
+{
+    if (_instance != nullptr)
+    {
+        return (nullptr);
+    }
+
+    Rtc *candidate = new Rtc();
+    if (!candidate->_initialised)
+    {
+        delete candidate;
+        return (nullptr);
+    }
+
+    _instance = candidate;
+    return (_instance);
+}
+
+// =============================================================================
+// Constructor / Destructor
+// =============================================================================
+
+Rtc::Rtc() : _busHandle(nullptr), _deviceHandle(nullptr), _initialised(false)
+{
+    // Open an I2C master bus on the Tab5 RTC pins.
+    i2c_master_bus_config_t busConfig = {};
+    busConfig.i2c_port = I2C_NUM_0;
+    busConfig.sda_io_num = RTC_SDA_PIN;
+    busConfig.scl_io_num = RTC_SCL_PIN;
+    busConfig.clk_source = I2C_CLK_SRC_DEFAULT;
+    busConfig.glitch_ignore_cnt = 7;
+    busConfig.flags.enable_internal_pullup = true;
+
+    esp_err_t result = i2c_new_master_bus(&busConfig, &_busHandle);
+    if (result != ESP_OK)
+    {
+        ESP_LOGE(LOG_TAG, "Failed to create I2C master bus: %s", esp_err_to_name(result));
+        return;
+    }
+
+    // Add the RX8130CE device to the bus.
+    i2c_device_config_t deviceConfig = {};
+    deviceConfig.dev_addr_length = I2C_ADDR_BIT_LEN_7;
+    deviceConfig.device_address = I2C_ADDRESS;
+    deviceConfig.scl_speed_hz = I2C_FREQUENCY_HZ;
+
+    result = i2c_master_bus_add_device(_busHandle, &deviceConfig, &_deviceHandle);
+    if (result != ESP_OK)
+    {
+        ESP_LOGE(LOG_TAG, "Failed to add RX8130CE device to I2C bus: %s", esp_err_to_name(result));
+        i2c_del_master_bus(_busHandle);
+        _busHandle = nullptr;
+        return;
+    }
+
+    _initialised = PerformStartup();
+}
+
+Rtc::~Rtc()
+{
+    if (_deviceHandle != nullptr)
+    {
+        // Disable all active interrupts before releasing the hardware.
+        EnableAlarmInterrupt(false);
+        StopWakeupTimer();
+
+        i2c_master_bus_rm_device(_deviceHandle);
+        _deviceHandle = nullptr;
+    }
+
+    if (_busHandle != nullptr)
+    {
+        i2c_del_master_bus(_busHandle);
+        _busHandle = nullptr;
+    }
+
+    _instance = nullptr;
+}
+
+// =============================================================================
+// Time
+// =============================================================================
+
+bool Rtc::GetTime(struct tm &time) const
+{
+    uint8_t buffer[7] = {};
+    if (!ReadRegisters(REG_SEC, buffer, sizeof(buffer)))
+    {
+        return (false);
+    }
+
+    time.tm_sec  = static_cast<int>(BcdToDec(buffer[0] & 0x7F));
+    time.tm_min  = static_cast<int>(BcdToDec(buffer[1] & 0x7F));
+    time.tm_hour = static_cast<int>(BcdToDec(buffer[2] & 0x3F));
+
+    // Weekday register is one-hot: bit 0 = Sunday, bit 6 = Saturday.
+    uint8_t weekdayBit = buffer[3] & 0x7F;
+    int weekday = 0;
+    while (weekdayBit > 1)
+    {
+        weekdayBit >>= 1;
+        weekday++;
+    }
+    time.tm_wday = weekday;
+
+    time.tm_mday = static_cast<int>(BcdToDec(buffer[4] & 0x3F));
+    time.tm_mon  = static_cast<int>(BcdToDec(buffer[5] & 0x1F)) - 1;
+    time.tm_year = static_cast<int>(BcdToDec(buffer[6])) + TM_YEAR_OFFSET_2000;
+    time.tm_isdst = -1;
+
+    return (true);
+}
+
+bool Rtc::SetTime(const struct tm &time)
+{
+    if (!SetStop(true))
+    {
+        return (false);
+    }
+
+    uint8_t buffer[7] = {};
+    buffer[0] = DecToBcd(static_cast<uint8_t>(time.tm_sec));
+    buffer[1] = DecToBcd(static_cast<uint8_t>(time.tm_min));
+    buffer[2] = DecToBcd(static_cast<uint8_t>(time.tm_hour));
+    buffer[3] = static_cast<uint8_t>(1u << time.tm_wday);              // One-hot weekday
+    buffer[4] = DecToBcd(static_cast<uint8_t>(time.tm_mday));
+    buffer[5] = DecToBcd(static_cast<uint8_t>(time.tm_mon + 1));
+    buffer[6] = DecToBcd(static_cast<uint8_t>(time.tm_year - TM_YEAR_OFFSET_2000));
+
+    // Build the multi-byte write: register address followed by 7 data bytes.
+    uint8_t packet[8] = {};
+    packet[0] = REG_SEC;
+    memcpy(&packet[1], buffer, sizeof(buffer));
+
+    esp_err_t result = i2c_master_transmit(_deviceHandle, packet, sizeof(packet), I2C_TIMEOUT_MS);
+
+    // Restart the oscillator regardless of whether the write succeeded.
+    bool restartOk = SetStop(false);
+
+    return (result == ESP_OK && restartOk);
+}
+
+// =============================================================================
+// Alarm
+// =============================================================================
+
+bool Rtc::SetAlarm(const AlarmConfig &config)
+{
+    // Update the WADA bit in the Extension Register.
+    uint8_t extensionReg = 0;
+    if (!ReadRegisters(REG_EXTENSION, &extensionReg, 1))
+    {
+        return (false);
+    }
+
+    if (config.matchWeekday)
+    {
+        extensionReg &= ~EXT_WADA;
+    }
+    else
+    {
+        extensionReg |= EXT_WADA;
+    }
+
+    if (!WriteRegister(REG_EXTENSION, extensionReg))
+    {
+        return (false);
+    }
+
+    // Build the three alarm register bytes.  Bit 7 = 0 enables matching for
+    // that field; bit 7 = 1 disables it.
+    uint8_t alarmMinute = DecToBcd(config.minute);
+    uint8_t alarmHour   = DecToBcd(config.hour);
+    uint8_t alarmDay;
+
+    if (config.matchWeekday)
+    {
+        alarmDay = static_cast<uint8_t>(1u << config.day);  // One-hot encoding
+    }
+    else
+    {
+        alarmDay = DecToBcd(config.day);
+    }
+
+    if (!config.matchMinute)
+    {
+        alarmMinute |= ALARM_DISABLE_BIT;
+    }
+    if (!config.matchHour)
+    {
+        alarmHour |= ALARM_DISABLE_BIT;
+    }
+    if (!config.matchDay)
+    {
+        alarmDay |= ALARM_DISABLE_BIT;
+    }
+
+    uint8_t packet[4] = { REG_ALARM_MIN, alarmMinute, alarmHour, alarmDay };
+
+    esp_err_t result = i2c_master_transmit(_deviceHandle, packet, sizeof(packet), I2C_TIMEOUT_MS);
+    return (result == ESP_OK);
+}
+
+bool Rtc::GetAlarm(AlarmConfig &config) const
+{
+    uint8_t alarmBuffer[3] = {};
+    if (!ReadRegisters(REG_ALARM_MIN, alarmBuffer, sizeof(alarmBuffer)))
+    {
+        return (false);
+    }
+
+    uint8_t extensionReg = 0;
+    if (!ReadRegisters(REG_EXTENSION, &extensionReg, 1))
+    {
+        return (false);
+    }
+
+    config.matchMinute  = (alarmBuffer[0] & ALARM_DISABLE_BIT) == 0;
+    config.matchHour    = (alarmBuffer[1] & ALARM_DISABLE_BIT) == 0;
+    config.matchDay     = (alarmBuffer[2] & ALARM_DISABLE_BIT) == 0;
+    config.matchWeekday = (extensionReg & EXT_WADA) == 0;
+
+    config.minute = BcdToDec(alarmBuffer[0] & 0x7F);
+    config.hour   = BcdToDec(alarmBuffer[1] & 0x7F);
+
+    if (config.matchWeekday)
+    {
+        // Decode one-hot weekday back to 0–6.
+        uint8_t weekdayBit = alarmBuffer[2] & 0x7F;
+        int weekday = 0;
+        while (weekdayBit > 1)
+        {
+            weekdayBit >>= 1;
+            weekday++;
+        }
+        config.day = static_cast<uint8_t>(weekday);
+    }
+    else
+    {
+        config.day = BcdToDec(alarmBuffer[2] & 0x3F);
+    }
+
+    return (true);
+}
+
+bool Rtc::EnableAlarmInterrupt(bool enable)
+{
+    uint8_t control0 = 0;
+    if (!ReadRegisters(REG_CONTROL0, &control0, 1))
+    {
+        return (false);
+    }
+
+    if (enable)
+    {
+        control0 |= CTRL0_AIE;
+    }
+    else
+    {
+        control0 &= ~CTRL0_AIE;
+    }
+
+    return (WriteRegister(REG_CONTROL0, control0));
+}
+
+// =============================================================================
+// Wakeup timer
+// =============================================================================
+
+bool Rtc::StartWakeupTimer(uint16_t countdownValue,
+                            TimerClockSource clockSource,
+                            bool enableInterrupt)
+{
+    // Stop the timer before modifying its registers.
+    uint8_t extensionReg = 0;
+    if (!ReadRegisters(REG_EXTENSION, &extensionReg, 1))
+    {
+        return (false);
+    }
+
+    extensionReg &= ~EXT_TE;
+    if (!WriteRegister(REG_EXTENSION, extensionReg))
+    {
+        return (false);
+    }
+
+    // Write the 16-bit countdown value (little-endian: L byte then H byte).
+    const uint8_t timerLow  = static_cast<uint8_t>(countdownValue & 0xFF);
+    const uint8_t timerHigh = static_cast<uint8_t>((countdownValue >> 8) & 0xFF);
+    uint8_t timerPacket[3] = { REG_TIMER_LOW, timerLow, timerHigh };
+
+    esp_err_t result = i2c_master_transmit(_deviceHandle, timerPacket, sizeof(timerPacket), I2C_TIMEOUT_MS);
+    if (result != ESP_OK)
+    {
+        return (false);
+    }
+
+    // Set the clock source and re-enable the timer.
+    extensionReg &= ~EXT_TSEL_MASK;
+    extensionReg |= (static_cast<uint8_t>(clockSource) & EXT_TSEL_MASK);
+    extensionReg |= EXT_TE;
+
+    if (!WriteRegister(REG_EXTENSION, extensionReg))
+    {
+        return (false);
+    }
+
+    // Configure the timer interrupt bit in Control Register 0.
+    uint8_t control0 = 0;
+    if (!ReadRegisters(REG_CONTROL0, &control0, 1))
+    {
+        return (false);
+    }
+
+    if (enableInterrupt)
+    {
+        control0 |= CTRL0_TIE;
+    }
+    else
+    {
+        control0 &= ~CTRL0_TIE;
+    }
+
+    return (WriteRegister(REG_CONTROL0, control0));
+}
+
+bool Rtc::StopWakeupTimer()
+{
+    uint8_t extensionReg = 0;
+    if (!ReadRegisters(REG_EXTENSION, &extensionReg, 1))
+    {
+        return (false);
+    }
+
+    extensionReg &= ~EXT_TE;
+    if (!WriteRegister(REG_EXTENSION, extensionReg))
+    {
+        return (false);
+    }
+
+    uint8_t control0 = 0;
+    if (!ReadRegisters(REG_CONTROL0, &control0, 1))
+    {
+        return (false);
+    }
+
+    control0 &= ~CTRL0_TIE;
+    return (WriteRegister(REG_CONTROL0, control0));
+}
+
+// =============================================================================
+// Status flags
+// =============================================================================
+
+Rtc::StatusFlags Rtc::GetFlags() const
+{
+    uint8_t flagReg = 0;
+    ReadRegisters(REG_FLAG, &flagReg, 1);
+    return (flagReg);
+}
+
+bool Rtc::ClearFlags(StatusFlags flags)
+{
+    uint8_t flagReg = 0;
+    if (!ReadRegisters(REG_FLAG, &flagReg, 1))
+    {
+        return (false);
+    }
+
+    flagReg &= ~flags;
+    return (WriteRegister(REG_FLAG, flagReg));
+}
+
+// =============================================================================
+// Private helpers
+// =============================================================================
+
+bool Rtc::WriteRegister(uint8_t registerAddress, uint8_t value) const
+{
+    uint8_t packet[2] = { registerAddress, value };
+    esp_err_t result = i2c_master_transmit(_deviceHandle, packet, sizeof(packet), I2C_TIMEOUT_MS);
+    return (result == ESP_OK);
+}
+
+bool Rtc::ReadRegisters(uint8_t registerAddress, uint8_t *buffer, size_t length) const
+{
+    esp_err_t result = i2c_master_transmit_receive(
+        _deviceHandle,
+        &registerAddress, 1,
+        buffer, length,
+        I2C_TIMEOUT_MS);
+    return (result == ESP_OK);
+}
+
+uint8_t Rtc::BcdToDec(uint8_t bcd)
+{
+    return (static_cast<uint8_t>(((bcd >> 4) * 10) + (bcd & 0x0F)));
+}
+
+uint8_t Rtc::DecToBcd(uint8_t decimal)
+{
+    return (static_cast<uint8_t>(((decimal / 10) << 4) | (decimal % 10)));
+}
+
+bool Rtc::SetStop(bool stop)
+{
+    uint8_t control0 = 0;
+    if (!ReadRegisters(REG_CONTROL0, &control0, 1))
+    {
+        return (false);
+    }
+
+    if (stop)
+    {
+        control0 |= CTRL0_STOP;
+    }
+    else
+    {
+        control0 &= ~CTRL0_STOP;
+    }
+
+    return (WriteRegister(REG_CONTROL0, control0));
+}
+
+bool Rtc::PerformStartup()
+{
+    // §8.3: Wait at least 30 ms after power-on before the first access.
+    vTaskDelay(pdMS_TO_TICKS(STARTUP_WAIT_MS));
+
+    // Dummy read — ignore ACK/NACK (chip may not yet be ready).
+    uint8_t dummy = 0;
+    i2c_master_transmit_receive(_deviceHandle, &dummy, 1, &dummy, 1, 1);
+
+    // Read the Flag Register to check the VLF (oscillation-stop) flag.
+    uint8_t flagReg = 0;
+    if (!ReadRegisters(REG_FLAG, &flagReg, 1))
+    {
+        ESP_LOGE(LOG_TAG, "Could not read Flag Register — RX8130CE not found on I2C bus");
+        return (false);
+    }
+
+    if (flagReg & FLAG_VLF)
+    {
+        ESP_LOGW(LOG_TAG, "VLF flag set — oscillator was stopped.  Performing software reset.");
+
+        // Software reset sequence from the RX8130CE datasheet / application note.
+        WriteRegister(REG_CONTROL0, 0x00);
+        WriteRegister(REG_CONTROL0, CTRL0_STOP);
+        WriteRegister(0x50, 0x6C);  // Undocumented internal reset register
+        WriteRegister(0x53, 0x01);  // Undocumented internal reset register
+        WriteRegister(0x66, 0x03);  // Undocumented internal reset register
+        WriteRegister(0x6B, 0x02);  // Undocumented internal reset register
+        WriteRegister(0x6B, 0x01);  // Undocumented internal reset register
+
+        vTaskDelay(pdMS_TO_TICKS(RESET_WAIT_MS));
+
+        // Clear the VLF flag and restart the oscillator.
+        uint8_t clearedFlag = 0;
+        if (!ReadRegisters(REG_FLAG, &clearedFlag, 1))
+        {
+            return (false);
+        }
+        clearedFlag &= ~FLAG_VLF;
+        WriteRegister(REG_FLAG, clearedFlag);
+        SetStop(false);
+
+        ESP_LOGW(LOG_TAG, "Software reset complete — please set the time.");
+    }
+
+    ESP_LOGI(LOG_TAG, "RX8130CE initialised successfully");
+    return (true);
+}

--- a/components/Tab5/Rtc.hpp
+++ b/components/Tab5/Rtc.hpp
@@ -294,11 +294,11 @@ private:
     /** @brief I2C clock frequency for RTC communication. */
     static constexpr uint32_t I2C_FREQUENCY_HZ = 400000;
 
-    /** @brief I2C SDA pin (Tab5 RTC bus). */
-    static constexpr gpio_num_t RTC_SDA_PIN = GPIO_NUM_7;
+    /** @brief I2C SDA pin — shared internal bus, GPIO 31. */
+    static constexpr gpio_num_t RTC_SDA_PIN = GPIO_NUM_31;
 
-    /** @brief I2C SCL pin (Tab5 RTC bus). */
-    static constexpr gpio_num_t RTC_SCL_PIN = GPIO_NUM_8;
+    /** @brief I2C SCL pin — shared internal bus, GPIO 32. */
+    static constexpr gpio_num_t RTC_SCL_PIN = GPIO_NUM_32;
 
     // =========================================================================
     // Register addresses
@@ -410,4 +410,7 @@ private:
 
     /** @brief True once the chip has been successfully initialised. */
     bool _initialised;
+
+    /** @brief True if this instance created the I2C bus and must delete it on destruction. */
+    bool _busOwned;
 };

--- a/components/Tab5/Rtc.hpp
+++ b/components/Tab5/Rtc.hpp
@@ -1,0 +1,416 @@
+/*-----------------------------------------------------------------------------
+ * File        : Rtc.hpp
+ * Description : Singleton class (Rtc) for the Epson RX8130CE real-time clock
+ *               on the M5Stack Tab5.  Provides time get/set, three alarm
+ *               channels (minute, hour, day/week), and wakeup-timer interrupt
+ *               support via the chip's /IRQ output and a configurable GPIO.
+ * Author      : Mark Stevens
+ * Copyright   : Copyright (c) 2026 Mark Stevens
+ * Licence     : MIT — see LICENSE in the repository root for full terms.
+ * Target      : M5Stack Tab5 (ESP32-P4)
+ * Build system: ESP-IDF v5.5.1
+ *---------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <cstdint>
+#include <ctime>
+#include <driver/gpio.h>
+#include <driver/i2c_master.h>
+
+/**
+ * @brief Singleton driver for the Epson RX8130CE RTC on the M5Stack Tab5.
+ *
+ * The RX8130CE communicates over I2C at address 0x32.  This class exposes:
+ *
+ *  - Time read/write using the standard C `struct tm`.
+ *  - Day/date alarm with independent enable bits for minute, hour, and day.
+ *  - Wakeup-timer countdown interrupt at selectable clock sources.
+ *  - Interrupt flag inspection and clearing.
+ *
+ * Interrupt wakeup from deep-sleep is routed via the PMS150G-U06 companion
+ * MCU from the RX8130CE /IRQ pin.  The caller is responsible for configuring
+ * the ESP32-P4 deep-sleep wakeup source via esp_sleep_enable_ext0_wakeup()
+ * after the alarm or timer has been configured through this class.
+ *
+ * @note Only one instance may exist at a time.  Calling Initialise() when the
+ *       singleton already exists returns nullptr.
+ *
+ * @note The first call to Initialise() performs a dummy-read, checks the
+ *       VLF (oscillation-stop) flag, and issues a software reset if the
+ *       oscillator was stopped.  The application must set the correct time
+ *       after any power-on reset or software reset.
+ */
+class Rtc
+{
+public:
+    // =========================================================================
+    // Types
+    // =========================================================================
+
+    /**
+     * @brief Alarm match fields.
+     *
+     * Each field is independently enabled or disabled.  Unset fields are
+     * ignored by the hardware.  The WADA bit in the Extension Register selects
+     * whether the Day field matches the day-of-month or day-of-week.
+     */
+    struct AlarmConfig
+    {
+        /** @brief Enable matching on the minute field. */
+        bool matchMinute = false;
+
+        /** @brief Enable matching on the hour field. */
+        bool matchHour = false;
+
+        /** @brief Enable matching on the day field (day-of-month or weekday). */
+        bool matchDay = false;
+
+        /** @brief Minute value to match (0–59). */
+        uint8_t minute = 0;
+
+        /** @brief Hour value to match (0–23). */
+        uint8_t hour = 0;
+
+        /**
+         * @brief Day value to match.
+         *
+         * When matchWeekday is false: day-of-month 1–31.
+         * When matchWeekday is true: weekday 0 (Sunday) – 6 (Saturday).
+         */
+        uint8_t day = 0;
+
+        /**
+         * @brief Select day-of-week matching instead of day-of-month.
+         *
+         * Sets the WADA bit in the Extension Register.  When true the day
+         * register stores a weekday bitmask (bit 0 = Sunday … bit 6 = Saturday).
+         */
+        bool matchWeekday = false;
+    };
+
+    /**
+     * @brief Wakeup-timer clock source selection (TSEL bits).
+     */
+    enum class TimerClockSource : uint8_t
+    {
+        /** @brief 4096 Hz — smallest period, highest resolution. */
+        Hz4096 = 0x00,
+
+        /** @brief 64 Hz. */
+        Hz64 = 0x01,
+
+        /** @brief 1 Hz — one second per count. */
+        Hz1 = 0x02,
+
+        /** @brief 1/60 Hz — one minute per count. */
+        Per60Seconds = 0x03,
+
+        /** @brief 1/3600 Hz — one hour per count (≈0.000278 Hz). */
+        Per3600Seconds = 0x04,
+    };
+
+    /**
+     * @brief Status flags from Flag Register (0x1D).
+     *
+     * Bits are ORed together; use the individual flag constants to test.
+     */
+    using StatusFlags = uint8_t;
+
+    /** @brief VBLF — VBAT low-voltage detection. */
+    static constexpr StatusFlags FLAG_VBAT_LOW = 0x80;
+
+    /** @brief UF — time-update interrupt fired. */
+    static constexpr StatusFlags FLAG_UPDATE = 0x20;
+
+    /** @brief TF — wakeup-timer interrupt fired. */
+    static constexpr StatusFlags FLAG_TIMER = 0x10;
+
+    /** @brief AF — alarm interrupt fired. */
+    static constexpr StatusFlags FLAG_ALARM = 0x08;
+
+    /** @brief RSF — voltage-drop detected (/RST asserted). */
+    static constexpr StatusFlags FLAG_RESET = 0x04;
+
+    /** @brief VLF — oscillation-stop detected. */
+    static constexpr StatusFlags FLAG_VLF = 0x02;
+
+    /** @brief VBFF — VBAT fully charged. */
+    static constexpr StatusFlags FLAG_VBAT_FULL = 0x01;
+
+    // =========================================================================
+    // Singleton interface
+    // =========================================================================
+
+    /**
+     * @brief Returns the existing singleton instance.
+     *
+     * @return Pointer to the singleton, or nullptr if Initialise() has not
+     *         yet been called.
+     */
+    static Rtc *GetInstance();
+
+    /**
+     * @brief Creates and initialises the singleton.
+     *
+     * Opens an I2C master bus on the Tab5 RTC I2C pins, verifies the chip
+     * is present, checks the VLF flag, and performs a software reset if
+     * the oscillator was stopped.
+     *
+     * @return Pointer to the newly created singleton, or nullptr if the
+     *         singleton already exists or initialisation fails.
+     */
+    static Rtc *Initialise();
+
+    /**
+     * @brief Destructor.
+     *
+     * Stops any active alarm or timer interrupt, releases the I2C device
+     * handle, deletes the I2C master bus, and resets the singleton pointer
+     * so that Initialise() may be called again.
+     */
+    ~Rtc();
+
+    // =========================================================================
+    // Time
+    // =========================================================================
+
+    /**
+     * @brief Reads the current time from the RTC into a standard tm struct.
+     *
+     * Year is stored as years since 1900 (matching struct tm convention).
+     * Month is 0-based (0 = January).
+     *
+     * @param[out] time  Struct to fill with the current date and time.
+     * @return true on success; false if the I2C transaction failed.
+     */
+    bool GetTime(struct tm &time) const;
+
+    /**
+     * @brief Sets the RTC time from a standard tm struct.
+     *
+     * Stops the timekeeping oscillator during the write and restarts it
+     * immediately after, per the datasheet requirement.
+     *
+     * @param time  Date and time to write.  Year is years-since-1900;
+     *              month is 0-based.
+     * @return true on success; false if the I2C transaction failed.
+     */
+    bool SetTime(const struct tm &time);
+
+    // =========================================================================
+    // Alarm
+    // =========================================================================
+
+    /**
+     * @brief Configures the alarm registers.
+     *
+     * Writes the alarm minute (0x17), hour (0x18), and day/week (0x19)
+     * registers and sets the WADA bit in the Extension Register.  Does NOT
+     * automatically enable the alarm interrupt — call EnableAlarmInterrupt()
+     * separately.
+     *
+     * @param config  Alarm match configuration.
+     * @return true on success.
+     */
+    bool SetAlarm(const AlarmConfig &config);
+
+    /**
+     * @brief Reads the current alarm register settings.
+     *
+     * @param[out] config  Filled with the current alarm configuration.
+     * @return true on success.
+     */
+    bool GetAlarm(AlarmConfig &config) const;
+
+    /**
+     * @brief Enables or disables the alarm interrupt (AIE bit in Control 0).
+     *
+     * When enabled, the RX8130CE asserts /IRQ LOW when the alarm time is
+     * reached.  Clear the AF flag via ClearFlags() to deassert /IRQ.
+     *
+     * @param enable  true to enable; false to disable.
+     * @return true on success.
+     */
+    bool EnableAlarmInterrupt(bool enable);
+
+    // =========================================================================
+    // Wakeup timer
+    // =========================================================================
+
+    /**
+     * @brief Configures and starts the countdown wakeup timer.
+     *
+     * Writes the 16-bit countdown value to registers 0x1A–0x1B, sets the
+     * clock source, enables the timer (TE bit), and optionally enables the
+     * timer interrupt (TIE bit).
+     *
+     * @param countdownValue    Initial countdown value (1–65535).  The time
+     *                          until interrupt = countdownValue / clockFrequency.
+     * @param clockSource       Clock source that determines tick frequency.
+     * @param enableInterrupt   true to assert /IRQ when the counter reaches zero.
+     * @return true on success.
+     */
+    bool StartWakeupTimer(uint16_t countdownValue,
+                          TimerClockSource clockSource,
+                          bool enableInterrupt);
+
+    /**
+     * @brief Stops the wakeup timer and disables its interrupt.
+     *
+     * Clears the TE and TIE bits without modifying the countdown value.
+     *
+     * @return true on success.
+     */
+    bool StopWakeupTimer();
+
+    // =========================================================================
+    // Status flags
+    // =========================================================================
+
+    /**
+     * @brief Reads the current status flags from Flag Register 0x1D.
+     *
+     * @return Bitmask of StatusFlags constants; 0 if the read fails.
+     */
+    StatusFlags GetFlags() const;
+
+    /**
+     * @brief Clears the specified status flags in Flag Register 0x1D.
+     *
+     * Performs a read-modify-write so that only the requested bits are
+     * cleared.  Must be called after handling an interrupt to deassert /IRQ.
+     *
+     * @param flags  Bitmask of StatusFlags constants to clear.
+     * @return true on success.
+     */
+    bool ClearFlags(StatusFlags flags);
+
+private:
+    // =========================================================================
+    // Hardware constants
+    // =========================================================================
+
+    /** @brief RX8130CE 7-bit I2C address. */
+    static constexpr uint8_t I2C_ADDRESS = 0x32;
+
+    /** @brief I2C clock frequency for RTC communication. */
+    static constexpr uint32_t I2C_FREQUENCY_HZ = 400000;
+
+    /** @brief I2C SDA pin (Tab5 RTC bus). */
+    static constexpr gpio_num_t RTC_SDA_PIN = GPIO_NUM_7;
+
+    /** @brief I2C SCL pin (Tab5 RTC bus). */
+    static constexpr gpio_num_t RTC_SCL_PIN = GPIO_NUM_8;
+
+    // =========================================================================
+    // Register addresses
+    // =========================================================================
+
+    /** @brief First time register (seconds); 7 consecutive bytes through 0x16. */
+    static constexpr uint8_t REG_SEC = 0x10;
+
+    /** @brief Alarm minute register. */
+    static constexpr uint8_t REG_ALARM_MIN = 0x17;
+
+    /** @brief Wakeup timer low byte. */
+    static constexpr uint8_t REG_TIMER_LOW = 0x1A;
+
+    /** @brief Extension Register (FSEL, USEL, TE, WADA, TSEL). */
+    static constexpr uint8_t REG_EXTENSION = 0x1C;
+
+    /** @brief Flag Register (VBLF, UF, TF, AF, RSF, VLF, VBFF). */
+    static constexpr uint8_t REG_FLAG = 0x1D;
+
+    /** @brief Control Register 0 (TEST, STOP, UIE, TIE, AIE, TSTP, TBKON, TBKE). */
+    static constexpr uint8_t REG_CONTROL0 = 0x1E;
+
+    /** @brief Control Register 1 (SMPTSEL, CHGEN, INIEN, RSVSEL, BFVSEL). */
+    static constexpr uint8_t REG_CONTROL1 = 0x1F;
+
+    /** @brief Digital offset register. */
+    static constexpr uint8_t REG_OFFSET = 0x30;
+
+    // =========================================================================
+    // Constructor and helpers
+    // =========================================================================
+
+    /**
+     * @brief Private constructor — use Initialise() to create the singleton.
+     *
+     * Opens the I2C master bus and adds the RX8130CE device.  Throws no
+     * exceptions; check GetInstance() != nullptr for success.
+     */
+    Rtc();
+
+    /**
+     * @brief Writes one byte to an RX8130CE register.
+     *
+     * @param registerAddress  Target register address.
+     * @param value            Byte to write.
+     * @return true on I2C success.
+     */
+    bool WriteRegister(uint8_t registerAddress, uint8_t value) const;
+
+    /**
+     * @brief Reads one or more consecutive bytes from the RX8130CE.
+     *
+     * @param registerAddress  First register address to read.
+     * @param buffer           Destination buffer.
+     * @param length           Number of bytes to read.
+     * @return true on I2C success.
+     */
+    bool ReadRegisters(uint8_t registerAddress, uint8_t *buffer, size_t length) const;
+
+    /**
+     * @brief Converts a BCD-encoded byte to a decimal integer.
+     *
+     * @param bcd  BCD byte.
+     * @return Decimal value.
+     */
+    static uint8_t BcdToDec(uint8_t bcd);
+
+    /**
+     * @brief Converts a decimal integer (0–99) to BCD encoding.
+     *
+     * @param decimal  Value to convert.
+     * @return BCD byte.
+     */
+    static uint8_t DecToBcd(uint8_t decimal);
+
+    /**
+     * @brief Sets or clears the STOP bit in Control Register 0.
+     *
+     * Stopping the oscillator is required before writing time registers.
+     *
+     * @param stop  true to stop; false to restart.
+     * @return true on I2C success.
+     */
+    bool SetStop(bool stop);
+
+    /**
+     * @brief Performs the power-on initialisation sequence from the datasheet.
+     *
+     * Waits 30 ms, performs a dummy-read, checks the VLF flag, and issues
+     * a software reset if necessary.
+     *
+     * @return true if the chip is operational after initialisation.
+     */
+    bool PerformStartup();
+
+    // =========================================================================
+    // Members
+    // =========================================================================
+
+    /** @brief The single instance of this class. */
+    static Rtc *_instance;
+
+    /** @brief I2C master bus handle. */
+    i2c_master_bus_handle_t _busHandle;
+
+    /** @brief I2C device handle for the RX8130CE. */
+    i2c_master_dev_handle_t _deviceHandle;
+
+    /** @brief True once the chip has been successfully initialised. */
+    bool _initialised;
+};

--- a/components/Tab5/Rtc.hpp
+++ b/components/Tab5/Rtc.hpp
@@ -92,8 +92,7 @@ public:
     /**
      * @brief Wakeup-timer clock source selection (TSEL bits).
      */
-    enum class TimerClockSource : uint8_t
-    {
+    enum class TimerClockSource : uint8_t {
         /** @brief 4096 Hz — smallest period, highest resolution. */
         Hz4096 = 0x00,
 
@@ -251,9 +250,7 @@ public:
      * @param enableInterrupt   true to assert /IRQ when the counter reaches zero.
      * @return true on success.
      */
-    bool StartWakeupTimer(uint16_t countdownValue,
-                          TimerClockSource clockSource,
-                          bool enableInterrupt);
+    bool StartWakeupTimer(uint16_t countdownValue, TimerClockSource clockSource, bool enableInterrupt);
 
     /**
      * @brief Stops the wakeup timer and disables its interrupt.

--- a/main/Tab5Template.cpp
+++ b/main/Tab5Template.cpp
@@ -12,6 +12,7 @@
 
 #include <M5GFX.h>
 #include <cstdio>
+#include "Rtc.hpp"
 #include "SDCard.hpp"
 #include "Touch.hpp"
 
@@ -102,9 +103,10 @@ void Setup(void)
     // it as a falling-edge interrupt input.
     TouchInput::Initialise(display, OnTouchEvent);
 
-    // Initialise the microSD card before drawing the splash so its status can
-    // be included in a single display update.
+    // Initialise the microSD card and RTC before drawing the splash so their
+    // statuses can be included in a single display update.
     SDCard *sdCard = SDCard::Initialise();
+    Rtc *rtc = Rtc::Initialise();
 
     // -------------------------------------------------------------------------
     // Status splash — drawn once after all hardware is ready.
@@ -117,18 +119,18 @@ void Setup(void)
     const int centreX = display.width() / 2;
     const int centreY = display.height() / 2;
 
-    display.drawString("Tab5 Ready", centreX, centreY - 72);
+    display.drawString("Tab5 Ready", centreX, centreY - 96);
 
     // Touch subsystem status
     if (!display.touch())
     {
         display.setTextColor(TFT_RED, TFT_WHITE);
-        display.drawString("Touch: not found", centreX, centreY - 24);
+        display.drawString("Touch: not found", centreX, centreY - 48);
         display.setTextColor(TFT_BLACK, TFT_WHITE);
     }
     else
     {
-        display.drawString("Touch: OK", centreX, centreY - 24);
+        display.drawString("Touch: OK", centreX, centreY - 48);
     }
 
     // SD card mount status
@@ -140,12 +142,47 @@ void Setup(void)
 
         char sdInfo[64];
         snprintf(sdInfo, sizeof(sdInfo), "SD: %.1f GB  (%s)", sizeGb, card->cid.name);
-        display.drawString(sdInfo, centreX, centreY + 24);
+        display.drawString(sdInfo, centreX, centreY);
     }
     else
     {
         display.setTextColor(TFT_RED, TFT_WHITE);
-        display.drawString("SD card: not found", centreX, centreY + 24);
+        display.drawString("SD card: not found", centreX, centreY);
+        display.setTextColor(TFT_BLACK, TFT_WHITE);
+    }
+
+    // RTC status and current time
+    if (rtc != nullptr)
+    {
+        struct tm setTime = {};
+        setTime.tm_year = 2026 - 1900;
+        setTime.tm_mon = 3 - 1; // March (0-based)
+        setTime.tm_mday = 21;
+        setTime.tm_hour = 14;
+        setTime.tm_min = 42;
+        setTime.tm_sec = 0;
+        setTime.tm_wday = 6; // Saturday
+        setTime.tm_isdst = -1;
+        rtc->SetTime(setTime);
+
+        struct tm currentTime = {};
+        if (rtc->GetTime(currentTime))
+        {
+            char timeInfo[64];
+            snprintf(timeInfo, sizeof(timeInfo), "RTC: %04d-%02d-%02d %02d:%02d:%02d", currentTime.tm_year + 1900, currentTime.tm_mon + 1, currentTime.tm_mday, currentTime.tm_hour, currentTime.tm_min, currentTime.tm_sec);
+            display.drawString(timeInfo, centreX, centreY + 48);
+        }
+        else
+        {
+            display.setTextColor(TFT_RED, TFT_WHITE);
+            display.drawString("RTC: read failed", centreX, centreY + 48);
+            display.setTextColor(TFT_BLACK, TFT_WHITE);
+        }
+    }
+    else
+    {
+        display.setTextColor(TFT_RED, TFT_WHITE);
+        display.drawString("RTC: not found", centreX, centreY + 48);
         display.setTextColor(TFT_BLACK, TFT_WHITE);
     }
 

--- a/reformat-code.sh
+++ b/reformat-code.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+set -e
+scriptdir="$( cd "$(dirname "$0")" ; pwd -P )"
+
+#
+#   Work out the OS so that we can change actions per OS where necessary.
+#
+shopt -s nocasematch
+case "$(uname -a)" in
+  *darwin*)
+    OS="mac"
+    ;;
+  *linux*)
+    OS="linux"
+    ;;
+  cygwin*|mingw32*|msys*|mingw*)
+    OS="windows"
+    ;;
+  *)
+    OS="unknown"
+    ;;
+esac
+
+#
+# Check if the shell is interactive.
+#
+if [[ $- == *i* ]]; then
+  red=`tput setaf 1`
+  green=`tput setaf 2`
+  reset=`tput sgr0`
+fi
+
+VERBOSE=true
+HELP=false
+
+#
+#   Work out which options are on the command line.
+#
+for i in "$@"
+do
+case $i in
+    -v|--verbose)
+    VERBOSE=true
+    ;;
+    -h|--help)
+    HELP=true
+    ;;
+    *)
+    printf "Unknown command line option ($i)."
+    printf "Run build.sh --help for information on valid options."
+    exit 1
+    ;;
+esac
+done
+
+if $HELP; then
+    echo "$0: Build the ESP code for Meadow"
+    echo ""
+    echo "Default action: Build the ESP application in release mode."
+    echo ""
+    echo "Options:"
+    echo "-h | --help             Display this message"
+    echo "-v | --verbose          Display commands as they are executed (default)"
+    echo ""
+    exit 0
+fi
+
+run_command() {
+  if $VERBOSE || $DRYRUN; then
+    echo "Executing command: $1"
+    if ! $DRYRUN; then
+        $1
+    fi
+  else
+    if ! $DRYRUN; then
+        $1 &>/dev/null
+    fi
+  fi
+}
+
+check_command_status() {
+  exit_status=$?
+  if [ $exit_status -ne 0 ]; then
+    printf " ${red}error${reset}\n"
+    if ! $VERBOSE; then
+        printf "Re-run the script with --verbose flag to see the output.\n"
+    fi
+    exit 1
+  else
+    printf " ${green}success${reset}\n"
+  fi
+}
+
+#
+# Set the IDF variable in case we are running in a shell where eim has been used to install ESP-IDF.
+#
+clang-format -i $scriptdir/components/tab5/*.?pp
+clang-format -i $scriptdir/main/*.?pp
+find "$scriptdir/tests" -name "*.cpp" -o -name "*.hpp" -o -name "*.c" -o -name "*.h" | xargs clang-format -i
+
+now=$(date +"%T")
+printf "Reformatting code finished at $now\n"

--- a/tests/rtc/CMakeLists.txt
+++ b/tests/rtc/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(test_rtc)

--- a/tests/rtc/main/CMakeLists.txt
+++ b/tests/rtc/main/CMakeLists.txt
@@ -1,0 +1,14 @@
+idf_component_register(
+    SRCS
+        "RtcTest.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../../../components/Tab5/Rtc.cpp"
+    INCLUDE_DIRS
+        "."
+        "${CMAKE_CURRENT_SOURCE_DIR}/../../../components/Tab5"
+    REQUIRES
+        driver
+        esp_driver_i2c
+        unity
+        freertos
+        log
+)

--- a/tests/rtc/main/RtcTest.cpp
+++ b/tests/rtc/main/RtcTest.cpp
@@ -35,18 +35,16 @@
  * @param wday   Day of week (0 = Sunday, 6 = Saturday).
  * @return Populated struct tm.
  */
-static struct tm MakeTime(int year, int month, int day,
-                           int hour, int minute, int second,
-                           int wday)
+static struct tm MakeTime(int year, int month, int day, int hour, int minute, int second, int wday)
 {
     struct tm time = {};
-    time.tm_year  = year - 1900;
-    time.tm_mon   = month - 1;
-    time.tm_mday  = day;
-    time.tm_hour  = hour;
-    time.tm_min   = minute;
-    time.tm_sec   = second;
-    time.tm_wday  = wday;
+    time.tm_year = year - 1900;
+    time.tm_mon = month - 1;
+    time.tm_mday = day;
+    time.tm_hour = hour;
+    time.tm_min = minute;
+    time.tm_sec = second;
+    time.tm_wday = wday;
     time.tm_isdst = -1;
     return (time);
 }
@@ -95,16 +93,15 @@ static void TestRtcSetAndGetTimeRoundTrip(void)
     TEST_ASSERT_TRUE_MESSAGE(readOk, "GetTime() must return true");
 
     TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_year, read.tm_year, "Year must match");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_mon,  read.tm_mon,  "Month must match");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_mon, read.tm_mon, "Month must match");
     TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_mday, read.tm_mday, "Day must match");
     TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_hour, read.tm_hour, "Hour must match");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_min,  read.tm_min,  "Minute must match");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_min, read.tm_min, "Minute must match");
     TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_wday, read.tm_wday, "Weekday must match");
 
     // Seconds advance after SetTime so only verify they are in a plausible
     // range (0–5) rather than an exact value.
-    TEST_ASSERT_INT_WITHIN_MESSAGE(5, 0, read.tm_sec,
-                                   "Seconds must be within 5 of zero after 1.2 s");
+    TEST_ASSERT_INT_WITHIN_MESSAGE(5, 0, read.tm_sec, "Seconds must be within 5 of zero after 1.2 s");
 }
 
 /**
@@ -134,13 +131,11 @@ static void TestRtcTimeAdvancesCorrectly(void)
     TEST_ASSERT_TRUE_MESSAGE(readOk, "GetTime() must return true");
 
     TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_year, read.tm_year, "Year must be unchanged");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_mon,  read.tm_mon,  "Month must be unchanged");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_mon, read.tm_mon, "Month must be unchanged");
     TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_mday, read.tm_mday, "Day must be unchanged");
     TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_hour, read.tm_hour, "Hour must be unchanged");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_min + 1, read.tm_min,
-                                  "Minute must have incremented by 1");
-    TEST_ASSERT_INT_WITHIN_MESSAGE(2, 2, read.tm_sec,
-                                   "Seconds should be approximately 2 after crossing minute boundary");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_min + 1, read.tm_min, "Minute must have incremented by 1");
+    TEST_ASSERT_INT_WITHIN_MESSAGE(2, 2, read.tm_sec, "Seconds should be approximately 2 after crossing minute boundary");
 }
 
 /**
@@ -171,10 +166,10 @@ static void TestRtcYearBoundariesRoundTrip(void)
     struct tm read2099 = {};
     TEST_ASSERT_TRUE_MESSAGE(rtc->GetTime(read2099), "GetTime after year-2099 set must return true");
     TEST_ASSERT_EQUAL_INT_MESSAGE(year2099.tm_year, read2099.tm_year, "Year 2099 must round-trip");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(year2099.tm_mon,  read2099.tm_mon,  "Month 12 must round-trip");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(year2099.tm_mon, read2099.tm_mon, "Month 12 must round-trip");
     TEST_ASSERT_EQUAL_INT_MESSAGE(year2099.tm_mday, read2099.tm_mday, "Day 31 must round-trip");
     TEST_ASSERT_EQUAL_INT_MESSAGE(year2099.tm_hour, read2099.tm_hour, "Hour 23 must round-trip");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(year2099.tm_min,  read2099.tm_min,  "Minute 59 must round-trip");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(year2099.tm_min, read2099.tm_min, "Minute 59 must round-trip");
 }
 
 /**

--- a/tests/rtc/main/RtcTest.cpp
+++ b/tests/rtc/main/RtcTest.cpp
@@ -1,0 +1,251 @@
+/*-----------------------------------------------------------------------------
+ * File        : RtcTest.cpp
+ * Description : Unity test cases for the Rtc component.  Tests time set/get
+ *               round-trips on the Epson RX8130CE real-time clock fitted to
+ *               the M5Stack Tab5.  app_main initialises the RTC and then runs
+ *               all test cases explicitly via RUN_TEST so that results are
+ *               emitted in the standard Unity format.
+ * Author      : Mark Stevens
+ * Copyright   : Copyright (c) 2026 Mark Stevens
+ * Licence     : MIT — see LICENSE in the repository root for full terms.
+ * Target      : M5Stack Tab5 (ESP32-P4)
+ * Build system: ESP-IDF v5.5.1
+ *---------------------------------------------------------------------------*/
+
+#include <cstring>
+#include <ctime>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <unity.h>
+#include "Rtc.hpp"
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * @brief Fills a struct tm with a fully specified date and time.
+ *
+ * @param year   Gregorian year (e.g. 2026).
+ * @param month  1-based month (1 = January).
+ * @param day    Day of month (1–31).
+ * @param hour   Hour (0–23).
+ * @param minute Minute (0–59).
+ * @param second Second (0–59).
+ * @param wday   Day of week (0 = Sunday, 6 = Saturday).
+ * @return Populated struct tm.
+ */
+static struct tm MakeTime(int year, int month, int day,
+                           int hour, int minute, int second,
+                           int wday)
+{
+    struct tm time = {};
+    time.tm_year  = year - 1900;
+    time.tm_mon   = month - 1;
+    time.tm_mday  = day;
+    time.tm_hour  = hour;
+    time.tm_min   = minute;
+    time.tm_sec   = second;
+    time.tm_wday  = wday;
+    time.tm_isdst = -1;
+    return (time);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+/**
+ * @brief Verifies that Rtc::Initialise() returns a non-null pointer and that
+ *        GetInstance() returns the same pointer.
+ *
+ * This test relies on Rtc::Initialise() having been called in app_main before
+ * any RUN_TEST calls are made.
+ */
+static void TestRtcInitialisesSuccessfully(void)
+{
+    Rtc *rtc = Rtc::GetInstance();
+    TEST_ASSERT_NOT_NULL_MESSAGE(rtc, "Rtc singleton must exist after Initialise()");
+}
+
+/**
+ * @brief Sets a known date and time, reads it back, and verifies every field
+ *        matches.
+ *
+ * The set time is 2026-01-15 (Thursday) 10:30:00.  A one-second guard delay
+ * is introduced between SetTime and GetTime so that the oscillator has
+ * completed at least one tick cycle before the read.
+ */
+static void TestRtcSetAndGetTimeRoundTrip(void)
+{
+    Rtc *rtc = Rtc::GetInstance();
+    TEST_ASSERT_NOT_NULL(rtc);
+
+    // Thursday = weekday 4 (0=Sunday)
+    const struct tm written = MakeTime(2026, 1, 15, 10, 30, 0, 4);
+
+    const bool writeOk = rtc->SetTime(written);
+    TEST_ASSERT_TRUE_MESSAGE(writeOk, "SetTime() must return true");
+
+    // Allow the oscillator one full tick before reading back.
+    vTaskDelay(pdMS_TO_TICKS(1200));
+
+    struct tm read = {};
+    const bool readOk = rtc->GetTime(read);
+    TEST_ASSERT_TRUE_MESSAGE(readOk, "GetTime() must return true");
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_year, read.tm_year, "Year must match");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_mon,  read.tm_mon,  "Month must match");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_mday, read.tm_mday, "Day must match");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_hour, read.tm_hour, "Hour must match");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_min,  read.tm_min,  "Minute must match");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_wday, read.tm_wday, "Weekday must match");
+
+    // Seconds advance after SetTime so only verify they are in a plausible
+    // range (0–5) rather than an exact value.
+    TEST_ASSERT_INT_WITHIN_MESSAGE(5, 0, read.tm_sec,
+                                   "Seconds must be within 5 of zero after 1.2 s");
+}
+
+/**
+ * @brief Sets a time near a minute boundary, waits for the clock to tick past
+ *        it, then verifies that the minute field has incremented and the
+ *        second field has wrapped back to near zero.
+ *
+ * Set time is HH:MM:55.  After a 7-second delay the expected read-back is
+ * HH:(MM+1):02 ± 2 seconds.
+ */
+static void TestRtcTimeAdvancesCorrectly(void)
+{
+    Rtc *rtc = Rtc::GetInstance();
+    TEST_ASSERT_NOT_NULL(rtc);
+
+    // Wednesday = weekday 3
+    const struct tm written = MakeTime(2026, 3, 11, 14, 22, 55, 3);
+
+    const bool writeOk = rtc->SetTime(written);
+    TEST_ASSERT_TRUE_MESSAGE(writeOk, "SetTime() must return true");
+
+    // Wait 7 seconds — long enough for the clock to cross the minute boundary.
+    vTaskDelay(pdMS_TO_TICKS(7000));
+
+    struct tm read = {};
+    const bool readOk = rtc->GetTime(read);
+    TEST_ASSERT_TRUE_MESSAGE(readOk, "GetTime() must return true");
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_year, read.tm_year, "Year must be unchanged");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_mon,  read.tm_mon,  "Month must be unchanged");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_mday, read.tm_mday, "Day must be unchanged");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_hour, read.tm_hour, "Hour must be unchanged");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_min + 1, read.tm_min,
+                                  "Minute must have incremented by 1");
+    TEST_ASSERT_INT_WITHIN_MESSAGE(2, 2, read.tm_sec,
+                                   "Seconds should be approximately 2 after crossing minute boundary");
+}
+
+/**
+ * @brief Sets times at the extremes of the supported year range (2000 and
+ *        2099) and verifies each round-trips correctly without corruption.
+ *
+ * The RX8130CE stores year as a two-digit BCD value relative to 2000.
+ */
+static void TestRtcYearBoundariesRoundTrip(void)
+{
+    Rtc *rtc = Rtc::GetInstance();
+    TEST_ASSERT_NOT_NULL(rtc);
+
+    // Year 2000 — Saturday = weekday 6
+    const struct tm year2000 = MakeTime(2000, 1, 1, 0, 0, 0, 6);
+    TEST_ASSERT_TRUE_MESSAGE(rtc->SetTime(year2000), "SetTime(2000) must return true");
+    vTaskDelay(pdMS_TO_TICKS(200));
+
+    struct tm read2000 = {};
+    TEST_ASSERT_TRUE_MESSAGE(rtc->GetTime(read2000), "GetTime after year-2000 set must return true");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(year2000.tm_year, read2000.tm_year, "Year 2000 must round-trip");
+
+    // Year 2099 — Thursday = weekday 4
+    const struct tm year2099 = MakeTime(2099, 12, 31, 23, 59, 0, 4);
+    TEST_ASSERT_TRUE_MESSAGE(rtc->SetTime(year2099), "SetTime(2099) must return true");
+    vTaskDelay(pdMS_TO_TICKS(200));
+
+    struct tm read2099 = {};
+    TEST_ASSERT_TRUE_MESSAGE(rtc->GetTime(read2099), "GetTime after year-2099 set must return true");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(year2099.tm_year, read2099.tm_year, "Year 2099 must round-trip");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(year2099.tm_mon,  read2099.tm_mon,  "Month 12 must round-trip");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(year2099.tm_mday, read2099.tm_mday, "Day 31 must round-trip");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(year2099.tm_hour, read2099.tm_hour, "Hour 23 must round-trip");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(year2099.tm_min,  read2099.tm_min,  "Minute 59 must round-trip");
+}
+
+/**
+ * @brief Sets all twelve month values in sequence and verifies each reads back
+ *        correctly.
+ *
+ * A short delay separates each write/read pair.  The day is kept at 1 to
+ * avoid invalid day-in-month combinations.
+ */
+static void TestRtcAllMonthsRoundTrip(void)
+{
+    Rtc *rtc = Rtc::GetInstance();
+    TEST_ASSERT_NOT_NULL(rtc);
+
+    for (int month = 1; month <= 12; month++)
+    {
+        const struct tm written = MakeTime(2026, month, 1, 0, 0, 0, 0);
+        TEST_ASSERT_TRUE_MESSAGE(rtc->SetTime(written), "SetTime() must return true");
+        vTaskDelay(pdMS_TO_TICKS(200));
+
+        struct tm read = {};
+        TEST_ASSERT_TRUE_MESSAGE(rtc->GetTime(read), "GetTime() must return true");
+        TEST_ASSERT_EQUAL_INT_MESSAGE(written.tm_mon, read.tm_mon, "Month must round-trip");
+    }
+}
+
+/**
+ * @brief Verifies all valid weekday values (0–6) survive a write/read cycle.
+ *
+ * The RX8130CE stores weekday as a one-hot bitfield.  This test confirms that
+ * the conversion between integer (0–6) and one-hot encoding is correct for
+ * every day.
+ */
+static void TestRtcAllWeekdaysRoundTrip(void)
+{
+    Rtc *rtc = Rtc::GetInstance();
+    TEST_ASSERT_NOT_NULL(rtc);
+
+    for (int wday = 0; wday <= 6; wday++)
+    {
+        const struct tm written = MakeTime(2026, 2, 1 + wday, 12, 0, 0, wday);
+        TEST_ASSERT_TRUE_MESSAGE(rtc->SetTime(written), "SetTime() must return true");
+        vTaskDelay(pdMS_TO_TICKS(200));
+
+        struct tm read = {};
+        TEST_ASSERT_TRUE_MESSAGE(rtc->GetTime(read), "GetTime() must return true");
+        TEST_ASSERT_EQUAL_INT_MESSAGE(wday, read.tm_wday, "Weekday must round-trip");
+    }
+}
+
+// =============================================================================
+// Entry point
+// =============================================================================
+
+/**
+ * @brief Application entry point for the Rtc test suite.
+ *
+ * Initialises the RTC singleton then runs all test functions explicitly.
+ * Using RUN_TEST directly (rather than TEST_CASE auto-registration) avoids
+ * reliance on constructor-attribute linker tricks in C++ translation units
+ * and produces deterministic Unity output.
+ */
+extern "C" void app_main(void)
+{
+    Rtc::Initialise();
+    UNITY_BEGIN();
+    RUN_TEST(TestRtcInitialisesSuccessfully);
+    RUN_TEST(TestRtcSetAndGetTimeRoundTrip);
+    RUN_TEST(TestRtcTimeAdvancesCorrectly);
+    RUN_TEST(TestRtcYearBoundariesRoundTrip);
+    RUN_TEST(TestRtcAllMonthsRoundTrip);
+    RUN_TEST(TestRtcAllWeekdaysRoundTrip);
+    UNITY_END();
+}

--- a/tests/rtc/sdkconfig.defaults
+++ b/tests/rtc/sdkconfig.defaults
@@ -1,0 +1,19 @@
+# Rtc test app — minimal config for ESP32-P4 on Tab5 hardware.
+CONFIG_IDF_TARGET="esp32p4"
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+
+# Chip revision: the Tab5 uses ESP32-P4 silicon revision 0.x/1.x (reported by
+# esptool as 'v1.0').  ESP32P4_SELECTS_REV_LESS_V3 must be set first to unlock
+# the low-revision choice set; without it Kconfig only offers {300, 301}.
+CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y
+CONFIG_ESP32P4_REV_MIN_1=y
+
+# Disable Task Watchdog Timer so long vTaskDelay calls in the tests (e.g. the
+# 7-second minute-boundary test) do not starve the IDLE task.
+CONFIG_ESP_TASK_WDT_EN=n
+
+# PSRAM — ESP32-P4 uses HEX PSRAM (not OCT); 200MHz required for MIPI-DSI framebuffer DMA
+# CONFIG_SPIRAM_SPEED_200M depends on IDF_EXPERIMENTAL_FEATURES — both must be set together
+CONFIG_IDF_EXPERIMENTAL_FEATURES=y
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_SPEED_200M=y

--- a/tests/sdcard/main/SDCardTest.cpp
+++ b/tests/sdcard/main/SDCardTest.cpp
@@ -61,8 +61,7 @@ static void TestSDCardWriteAndReadBackMatches(void)
     fgets(buffer, static_cast<int>(sizeof(buffer)), file);
     fclose(file);
 
-    TEST_ASSERT_EQUAL_STRING_MESSAGE(TEST_WRITE_CONTENT, buffer,
-                                     "Read content must match written content");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE(TEST_WRITE_CONTENT, buffer, "Read content must match written content");
     remove(TEST_FILE_PATH);
 }
 
@@ -98,10 +97,8 @@ static void TestSDCardAppendModeAddsContent(void)
     firstLine[strcspn(firstLine, "\n")] = '\0';
     secondLine[strcspn(secondLine, "\n")] = '\0';
 
-    TEST_ASSERT_EQUAL_STRING_MESSAGE(TEST_WRITE_CONTENT, firstLine,
-                                     "First line must match initial write content");
-    TEST_ASSERT_EQUAL_STRING_MESSAGE(TEST_APPEND_CONTENT, secondLine,
-                                     "Second line must match appended content");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE(TEST_WRITE_CONTENT, firstLine, "First line must match initial write content");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE(TEST_APPEND_CONTENT, secondLine, "Second line must match appended content");
     remove(TEST_FILE_PATH);
 }
 


### PR DESCRIPTION
- Fix RTC I2C bus pins to GPIO 31/32 (internal bus, I2C_NUM_1)\n- Reuse M5GFX I2C bus handle\n- Display RTC time on splash screen\n- Update copilot-instructions.md